### PR TITLE
Better logging, upgraded dependencies

### DIFF
--- a/api/cardmaker/endpoints.py
+++ b/api/cardmaker/endpoints.py
@@ -8,7 +8,6 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, Response
-from fastapi.security import HTTPBasicCredentials
 
 from . import models, security, utils
 from .database import CardMakerDatabase
@@ -274,14 +273,13 @@ async def create_user(data: models.UserCreate):
 
 
 @router.post("/users/me")
-async def get_access_token(
-    credentials: Annotated[HTTPBasicCredentials, Depends(security.http_basic)]
-):
+async def get_access_token(data: models.UserLogin):
     """
     Generate JWT token for current user.
 
     Args:
-        credentials (HTTPBasicCredentials): username and password
+        data (models.UserLogin):
+                json request body, field are defined in models.UserLogin
 
     Returns:
         json response with status code 200:
@@ -291,7 +289,7 @@ async def get_access_token(
         HTTP 401: wrong credentials
     """
     user = await security.authenticate(
-        credentials.username, credentials.password
+        data.username, data.password
     )
     if not user:
         raise HTTPException(

--- a/api/cardmaker/logger.py
+++ b/api/cardmaker/logger.py
@@ -4,6 +4,7 @@ Script for python logger setup.
 
 import logging
 import sys
+import os
 
 
 class Logger(object):
@@ -40,15 +41,23 @@ class Logger(object):
         Setup for python logger.
         All messages are logged into file 'cardmaker-api.log' and stdout.
         """
+        self.logger = logging.getLogger("CardmakerApi")
         formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
 
-        file_handler = logging.FileHandler("cardmaker-api.log")
-        file_handler.setFormatter(formatter)
+        level = os.getenv("LOG_LEVEL")
+        if level is not None and level.lower() == "debug":
+            self.logger.setLevel(logging.DEBUG)
+        elif level is not None and level.lower() == "info":
+            self.logger.setLevel(logging.INFO)
+        else:
+            self.logger.setLevel(logging.WARNING)
 
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(formatter)
-
-        self.logger = logging.getLogger("CardmakerApi")
-        self.logger.setLevel(logging.WARNING)
-        self.logger.addHandler(file_handler)
         self.logger.addHandler(stream_handler)
+
+        logfile = os.getenv("LOG_LOGFILE")
+        if logfile is not None and logfile != "":
+            file_handler = logging.FileHandler(logfile)
+            file_handler.setFormatter(formatter)
+            self.logger.addHandler(file_handler)

--- a/api/cardmaker/logger.py
+++ b/api/cardmaker/logger.py
@@ -56,7 +56,7 @@ class Logger(object):
         stream_handler.setFormatter(formatter)
         self.logger.addHandler(stream_handler)
 
-        logfile = os.getenv("LOG_LOGFILE")
+        logfile = os.getenv("LOG_FILE")
         if logfile is not None and logfile != "":
             file_handler = logging.FileHandler(logfile)
             file_handler.setFormatter(formatter)

--- a/api/cardmaker/models.py
+++ b/api/cardmaker/models.py
@@ -32,8 +32,15 @@ class UserCreate(UserBase):
     """
 
     password: str
-    api_key: Optional[str]
+    api_key: Optional[str] = None
 
+
+class UserLogin(UserBase):
+    """
+    User model for and 'get_access_token' POST method.
+    """
+
+    password: str
 
 class UserPublic(UserBase):
     """
@@ -86,7 +93,7 @@ class TagBase(SQLModel):
     """
 
     name: str
-    description: Optional[str]
+    description: Optional[str] = None
 
 
 class Tag(TagBase, table=True):
@@ -112,8 +119,8 @@ class CardBase(SQLModel):
     fluff: Optional[str] = Field(max_length=4000)
     effect: Optional[str] = Field(max_length=4000)
     in_set: bool
-    set_name: Optional[str]
-    size: Optional[str]
+    set_name: Optional[str] = None
+    size: Optional[str] = None
 
 
 class CardCreate(CardBase):

--- a/api/main.py
+++ b/api/main.py
@@ -4,9 +4,16 @@ App for creating summer camp cards and saving them in database.
 
 import uvicorn
 from cardmaker import endpoints
+from cardmaker.logger import Logger
 from create_db import create_db
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import RequestResponseEndpoint
+from starlette.requests import Request
+import time
+from http.client import responses
+
+logger = Logger.get_instance()
 
 app = FastAPI(title="api")
 app.include_router(endpoints.router)
@@ -19,6 +26,31 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+@app.middleware("http")
+async def log(request: Request, call_next: RequestResponseEndpoint):
+    # Log request details
+    client_ip = request.client.host
+    client_port = request.client.port
+    method = request.method
+    url = request.url
+    headers = request.headers
+
+    t0 = time.time()
+    # Process the request
+    response = await call_next(request)
+    t = time.time() - t0
+
+    # Log response details
+    status_code = response.status_code
+    logger.info(f'REQ: {client_ip}:{client_port} {method} {url} {headers} RES: {status_code} {responses[status_code]} dur={int(1000*t)}ms')
+
+    return response
+
 if __name__ == "__main__":
     create_db()
-    uvicorn.run(app, host="0.0.0.0", port=8003)
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8003,
+        log_config=None,
+    )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,7 @@
 mysql-connector-python==8.4.0
-fastapi==0.85.0
-uvicorn==0.18.2
-sqlalchemy==2.0.30
-sqlmodel==0.0.18
-pyjwt==2.8.0
-bcrypt==4.2.0
+fastapi==0.115.12
+uvicorn==0.34.0
+sqlalchemy==2.0.40
+sqlmodel==0.0.24
+pyjwt==2.10.1
+bcrypt==4.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       SECRET_KEY: ${SECRET_KEY}
       API_KEY: ${API_KEY}
       USE_API_KEY: ${USE_API_KEY}
+      LOG_LEVEL: ${BACKEND_LOG_LEVEL}
+      LOG_FILE: ${BACKEND_LOG_FILE}
     depends_on:
       db:
         condition: service_healthy

--- a/example.env
+++ b/example.env
@@ -2,11 +2,12 @@ DATABASE_URL= "mysql+mysqlconnector://root:root@db:3307/Cardmaker"
 SECRET_KEY= "6de9b7c10564fb4794c13a2c127b5a00e21259cd56df440aad5199dae182966b"
 API_KEY="viroujimesalat"
 
-MYSQL_ROOT_PASSWORD="root"  
+MYSQL_ROOT_PASSWORD="root"
 MYSQL_DATABASE= "Cardmaker"
 MYSQL_USER= "user"
 MYSQL_PASSWORD= "pass"
 MYSQL_TCP_PORT="3307"
 
 API_KEY_USE="false" # "true" for use api key
+BACKEND_LOG_LEVEL="warning"
 BACKEND_LOG_FILE="cardmaker-api.log"

--- a/example.env
+++ b/example.env
@@ -9,3 +9,4 @@ MYSQL_PASSWORD= "pass"
 MYSQL_TCP_PORT="3307"
 
 API_KEY_USE="false" # "true" for use api key
+BACKEND_LOG_FILE="cardmaker-api.log"


### PR DESCRIPTION
# Better logging in backend

The backend logging has been improved in the following ways:

- Added a simple logging middleware to the FastAPI app which uses our logger, instead of the default logging from uvicorn which has been disabled.
- The logger now reads the `LOG_LEVEL` environment variable, which sets the log level. Setting the value (which is case insensitive) to `DEBUG` sets the debug level, `INFO` sets the info level, and anything else (i.e. any other string, or if the variable is not set at all) sets the level to warning, i.e. compatible with the situation before this PR.
- The logger now reads the `LOG_FILE` environment variable, which, if set, causes the log to also be written to the specified file, in addition to the stdout. To keep the behaviour before this PR, set the variable to `cardmaker-api.log` (see `example.env`).
- The `docker-compose.yml` file sets `LOG_LEVEL` and `LOG_LOGFILE` from the `BACKEND_LOG_LEVEL` and `BACKEND_LOG_FILE` variables respectively.

# Upgraded dependencies

The dependencies specified in `api/requirements.txt` have been upgraded to newer versions (to ease packaging in Nix).
Related to these upgrades, some changes were made to the backend:

- The login (`get_access_token()`) does not take an (annotated) `HTTPBasicCredentials` object, but a new model `models.UserLogin`, because during login, it is not HTTP Basic authentication that our app does (which happens via headers, and that is what the newer FastAPI does), but a simple POST with credentials (the response to which is a token for Bearer authentication which from then point on does take place via headers, which is set up correctly).
- Model classes with `Optional` fields that did not have a default value set have been given a default value of `None`, because newer Pydantic which came with newer FastAPI requires a default value.